### PR TITLE
(#64) - Changed user context variable from 'user' to 'target'

### DIFF
--- a/profiles/templates/profiles/index.html
+++ b/profiles/templates/profiles/index.html
@@ -11,8 +11,8 @@
 
 {% block body %}
     {% if users %}
-        {% for user in users %}
-            <a href="{% url 'profiles:user' user.id %}"> {{ user.username }} </a>
+        {% for target in users %}
+            <a href="{% url 'profiles:user' target.id %}"> {{ target.username }} </a>
             <br/>
         {% endfor %}
     {% else  %}

--- a/profiles/templates/profiles/user.html
+++ b/profiles/templates/profiles/user.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 {% block title %}
-    {{ user.username }}'s Profile
+    {{ target.username }}'s Profile
 {% endblock %}
 
 {% block links %}
@@ -13,7 +13,7 @@
 
 {% block body %}
     <div class="profile-container">
-        <h1> {{ user.username }} </h1>
+        <h1> {{ target.username }} </h1>
         {# User profile picture should go here when implemented #}
         <img class='profile-picture' src='{% static 'images/default-avatar.jpg' %}'
              alt="profile-avatar">

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -17,4 +17,4 @@ def index(request):
 def user(request, user_id):
     user_obj = CustomUser.objects.get(pk=user_id)
 
-    return render(request, 'profiles/user.html', {'user': user_obj})
+    return render(request, 'profiles/user.html', {'target': user_obj})


### PR DESCRIPTION
Don't send a context field to a template with the name 'user'. It overrides the default 'user' (request.user) automatically available in every template